### PR TITLE
Use YOCaml built-in server and remove collection

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,7 +20,7 @@ jobs:
       - run: opam install . --deps-only --with-doc --with-test
       - run: opam install yocaml
       - run: opam install yocaml_unix yocaml_yaml yocaml_markdown yocaml_jingoo
-      - run: opam exec -- dune exec src/angry_generator.exe
+      - run: opam exec -- dune exec src/angry_generator.exe -- build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.19.0
+version = 0.20.1
 profile = janestreet
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,15 @@ clean:
 clean-site:
 	rm -rf _site
 
-server:
-	python3 -m http.server --directory _site/
+fmt:
+	dune build @fmt --auto-promote
+
+server: build
+	./src/angry_generator.exe serve
 
 reload: clean clean-site
 	dune build
-	./src/angry_generator.exe
+	./src/angry_generator.exe build
 
 remove-deps:
 	opam remove yocaml yocaml_unix yocaml_yaml yocaml_markdown

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ First, make sure you have OCaml ('>= 4.11') and Opam installed. Then after downl
 > If some updates to `preface` or `yocaml` are not taken into account, feel free to remove the dependencies (`opam remove preface yocaml yocaml_unix`) before re-running the command call.
 
 - Now you can run `make build` to build the generator. It will produce a binary `src/angry_generator.exe`.
-- Running `./src/angry_generator.exe` will build the website into `_site/_`.
-- You can use `make server` in order to launch the sad `python simple server` on the generated website.
-- Your site will be alive on http://localhost:8000.
+- Running `./src/angry_generator.exe build` will build the website into `_site/angry_cuisine_nerd`.
+- You can use `make server` in order to launch the sad `YOCaml simple server` on the generated website.
+- Your site will be alive on http://localhost:8000/angry_cuisine_nerd.

--- a/angry_cuisine_nerd.opam
+++ b/angry_cuisine_nerd.opam
@@ -20,6 +20,7 @@ bug-reports: "https://github.com/BastienDuplessier/angry_cuisine_nerd/issues"
 depends: [
   "ocaml" { >= "4.11.1" }
   "dune" { >= "2.8" }
+  "logs" {>= "0.7.0" }
   "preface" { >= "0.1.0" }
   "yocaml" {pinned}
   "yocaml_unix" {pinned}

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 2.9)
+(name angry_cuisine_nerd)

--- a/src/angry_generator.ml
+++ b/src/angry_generator.ml
@@ -4,8 +4,18 @@ module Markup = Yocaml_markdown
 module Tpl = Yocaml_jingoo
 
 open struct
+  type strategy =
+    | Build
+    | Serve of int option
+    | Print_usage
+
+  let default_port = 8000
+
   (* Defines the destination directory *)
-  let target = "_site/angry_cuisine_nerd"
+  let root = "_site"
+  let folder = "angry_cuisine_nerd"
+  let target = folder |> into root
+  let binary = Sys.argv.(0)
 
   let get_recipe_url source =
     let filename = basename $ replace_extension source "html" in
@@ -15,7 +25,7 @@ open struct
   (* An arrow that recompiles a file if the binary, [angry_generator.exe] has
      been updated. An arrow that recompiles a file if the binary,
     [angry_generator.exe] has been updated (recompile after generation) *)
-  let track_binary = Build.watch Sys.argv.(0)
+  let track_binary = Build.watch binary
 
   (* Rule for copying CSS files to the correct destination directory. *)
   let css =
@@ -39,30 +49,95 @@ open struct
       >>^ Stdlib.snd)
   ;;
 
+  let get_recipe (module V : Metadata.VALIDABLE) recipe_file =
+    let arr =
+      Build.read_file_with_metadata
+        (module V)
+        (module Meta.Recipe)
+        recipe_file
+    in
+    let deps = Build.get_dependencies arr in
+    let task = Build.get_task arr in
+    let+ meta, _ = task () in
+    deps, (meta, get_recipe_url recipe_file)
+  ;;
+
+  let get_recipes (module V : Metadata.VALIDABLE) path =
+    let* files = read_child_files path (with_extension "md") in
+    let+ recipes = Traverse.traverse (get_recipe (module V)) files in
+    let deps, effects = List.split recipes in
+    Deps.Monoid.reduce deps, effects
+  ;;
+
+  let get_recipes_arrowized (module V : Metadata.VALIDABLE) path =
+    let+ deps, recipes = get_recipes (module V) path in
+    Build.make deps (fun x -> return (x, recipes))
+  ;;
+
   let index =
     let open Build in
-    let* recipes =
-      collection
-        (read_child_files "recipes/" (with_extension "md"))
-        (fun source ->
-          track_binary
-          >>> Data.read_file_with_metadata (module Meta.Recipe) source
-          >>^ fun (x, _) -> x, get_recipe_url source)
-        (fun x (_, content) -> x |> Meta.Recipes.make |> fun x -> x, content)
-    in
+    let* recipes = get_recipes_arrowized (module Data) "recipes" in
     create_file
       (into target "index.html")
       (track_binary
       >>> Data.read_file_with_metadata (module Metadata.Page) "index.md"
       >>> Markup.content_to_html ()
       >>> recipes
+      >>^ (fun ((_, content), m) -> Meta.Recipes.make m, content)
       >>> Tpl.apply_as_template (module Meta.Recipes) "templates/list.html"
       >>> Tpl.apply_as_template (module Meta.Recipes) "templates/layout.html"
       >>^ Stdlib.snd)
   ;;
+
+  let handle_serve len =
+    if len > 2
+    then
+      Sys.argv.(2)
+      |> int_of_string_opt
+      |> Option.fold ~none:Print_usage ~some:(fun port -> Serve (Some port))
+    else Serve None
+  ;;
+
+  let define_strategy () =
+    let len = Array.length Sys.argv in
+    if len < 2
+    then Print_usage
+    else (
+      let kind = String.lowercase_ascii Sys.argv.(1) in
+      match kind with
+      | "build" -> Build
+      | "serve" -> handle_serve len
+      | _ -> Print_usage)
+  ;;
 end
 
+(* Setup of the logger *)
 let () =
-  let open Yocaml in
-  Yocaml_unix.execute (css >> recipes >> index)
+  let () = Logs.set_level ~all:true (Some Logs.Info) in
+  Logs.set_reporter (Logs_fmt.reporter ())
+;;
+
+(* Run the program *)
+let () =
+  let program =
+    let open Yocaml in
+    css >> recipes >> index
+  in
+  match define_strategy () with
+  | Print_usage ->
+    Logs.warn (fun pp ->
+        pp
+          "usage: [ %s build ] or [ %s watch *port ], default port is %d"
+          binary
+          binary
+          default_port)
+  | Build -> Yocaml_unix.execute program
+  | Serve p ->
+    let port = Option.value ~default:default_port p in
+    let server = Yocaml_unix.serve ~filepath:root ~port program in
+    let () =
+      Logs.info (fun pp ->
+          pp "Website alive on http://localhost:%d/%s/" port folder)
+    in
+    Lwt_main.run server
 ;;

--- a/src/dune
+++ b/src/dune
@@ -1,10 +1,11 @@
- (executable
-  (name angry_generator)
-  (promote (until-clean))
+(executable
+ (name angry_generator)
+ (promote (until-clean))
  (libraries
-   preface
-   yocaml
-   yocaml_markdown
-   yocaml_yaml
-   yocaml_jingoo
-   yocaml_unix))
+  logs
+  preface
+  yocaml
+  yocaml_markdown
+  yocaml_yaml
+  yocaml_jingoo
+  yocaml_unix))


### PR DESCRIPTION
This patch uses YOCaml's brand new `built-in` server. It is likely that
the latter is neither efficient nor scalable, but it has the merit of
not being written in Python. In addition to not being efficient, the
server is very slow because, with each request (not leading to a 404),
it executes the YOCaml program that allows to build the site... _Pffrt_.

The big advantage of this approach is that you can write your
article (or recipe ;)) as you go along, without having to worry about
restarting the sad Python server. And since YOCaml is smart (coupled
with your article production frequency ;)), it shouldn't be a hindrance.

A good practice for building the blog would be to use a local switch:

```
opam switch create . ocaml-base-compiler.4.13.1
make install-deps
```

See ya.